### PR TITLE
Added release notes and a some improvements to the build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ services.AddDamSelectButton();
  ---
  ## Version History
 
- |Version| Details|
- |:---|:---------------|
- |1.0|Initial Release|
- |1.1|Added support to lineage API|
+ | Version | Details                                    |
+ |:--------|:-------------------------------------------|
+ | 1.2     | Supports EPiServer.CMS.TinyMce 3.x and 4.x |
+ | 1.1     | Added support to lineage API               |
+ | 1.0     | Initial Release                            |

--- a/TinymceDamPicker/EmbeddedLangFiles/TinymceDamPicker_EN.xml
+++ b/TinymceDamPicker/EmbeddedLangFiles/TinymceDamPicker_EN.xml
@@ -2,10 +2,10 @@
 <languages>
   <language name="English" id="en">
     <tinymcedampicker>
-      <title>TinymceDamPicker</title>
+      <title>File picker for Optimizely Dam</title>
 
       <gadget>
-        <title>TinymceDamPicker</title>
+        <title>Tinymce Dam Picker</title>
       </gadget>
 
       <client>

--- a/TinymceDamPicker/TinymceDamPicker.nuspec
+++ b/TinymceDamPicker/TinymceDamPicker.nuspec
@@ -4,7 +4,7 @@
         <id>TinymceDamPicker</id>
         <version>$version$</version>
         <title>DAM picker button for TinyMCE</title>
-        <authors>David Knipe</authors>
+        <authors>David Knipe, Steve Celius</authors>
         <owners>David Knipe</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>
@@ -14,7 +14,7 @@
         <repository type="git" url="https://github.com/davidknipe/TinymceDamPicker.git"/>
         <projectUrl>https://github.com/davidknipe/TinymceDamPicker</projectUrl>
         <releaseNotes>
-            Initial release, compatible with CMS 12 and EPiServer.CMS.TinyMce 3.x.
+            Compatible with CMS 12 and EPiServer.CMS.TinyMce 3.x and 4.x.
         </releaseNotes>
         <tags>EPiServerModulePackage EPiServerAddOn TinyMCE DAM</tags>
         <dependencies>


### PR DESCRIPTION
Creating the package uses full paths, not relative. Should make it more robust and easier to package. The release notes now show we're supporting both EPiServer.CMS.TinyMce 3.x and 4.x (both in CMS 12).