### PR TITLE
Update plugin.js

### DIFF
--- a/TinymceDamPicker/ClientResources/tinymcedampicker/plugin.js
+++ b/TinymceDamPicker/ClientResources/tinymcedampicker/plugin.js
@@ -177,9 +177,8 @@ tinyMCE.PluginManager.add("tinymcedampicker", (editor, url) => {
     const handleChoose = (event) => {
         const imageData = event.data[0];
         if (imageData) {
-            if (dialogOpen == false) {
-                dialog = openDialog();
-            }
+             dialog = openDialog();
+             dialogOpen = true;
             var altText = event.data[0].title;
             if (event.data[0].alt && event.data[0].alt != '') {
                 altText = event.data[0].alt;
@@ -239,7 +238,7 @@ tinyMCE.PluginManager.add("tinymcedampicker", (editor, url) => {
     const openWindow = () => {
         const options = {
             assetTypes: ['image'],
-            multiSelect: true
+            multiSelect: false
         };
         const encodedOptions = window.btoa(JSON.stringify(options));
         window.open(`https://cmp.optimizely.com/cloud/library-picker?pickerOptions=${encodedOptions}`, 'Library', 'popup');


### PR DESCRIPTION
1. Disable multi select as this CMP doesn't provide alt-text and metadata when we select more than a image or using check box.  2. Resolve issue when the dialog is not opening after when we click cancel.

