### PR TITLE
Feature/update tinymce 5 0

### DIFF
--- a/MSBuild/version.props
+++ b/MSBuild/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.2.5</VersionPrefix>
+    <VersionPrefix>1.2.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ services.AddDamSelectButton();
 
  | Version | Details                                                                        |
  |:--------|:-------------------------------------------------------------------------------|
+ | 1.2.6   | Adding support for EPiServer.CMS.TinyMce 5.0                                   | 
  | 1.2.5   | Bug fix: Prevent multi-select. Thanks for the contribution AnnamalaiEswaran-A! | 
  | 1.2.4   | Bug fix: Ensure auto-save works when in forms view                             | 
  | 1.2.3   | Bug fix: Resolve issue where multiple images cannot be inserted                | 

--- a/TinymceDamPicker/TinymceDamPicker.nuspec
+++ b/TinymceDamPicker/TinymceDamPicker.nuspec
@@ -19,7 +19,7 @@
         <tags>EPiServerModulePackage EPiServerAddOn TinyMCE DAM</tags>
         <dependencies>
              <group targetFramework="net6.0">
-                <dependency id="EPiServer.CMS.TinyMce" version="[$tinyVersion$,$tinyNextMajorVersion$)" />
+                <dependency id="EPiServer.CMS.TinyMce" version="[$tinyVersion$,$tinyNextMajorVersion$]" />
                 <dependency id="Microsoft.Extensions.FileProviders.Embedded" version="[6.0.5,)" />
                 <dependency id="EPiServer.CMS.WelcomeIntegration.UI" version="[1.3.6,)" />
             </group>

--- a/TinymceDamPicker/TinymceDamPicker.nuspec
+++ b/TinymceDamPicker/TinymceDamPicker.nuspec
@@ -4,7 +4,7 @@
         <id>TinymceDamPicker</id>
         <version>$version$</version>
         <title>DAM picker button for TinyMCE</title>
-        <authors>David Knipe, Steve Celius</authors>
+        <authors>David Knipe, Steve Celius, Michelangelo Accettura III</authors>
         <owners>David Knipe</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>
@@ -14,7 +14,7 @@
         <repository type="git" url="https://github.com/davidknipe/TinymceDamPicker.git"/>
         <projectUrl>https://github.com/davidknipe/TinymceDamPicker</projectUrl>
         <releaseNotes>
-            Compatible with CMS 12 and EPiServer.CMS.TinyMce 3.x and 4.x.
+            Compatible with CMS 12 and EPiServer.CMS.TinyMce 3.x, 4.x and 5.0.
         </releaseNotes>
         <tags>EPiServerModulePackage EPiServerAddOn TinyMCE DAM</tags>
         <dependencies>


### PR DESCRIPTION
Fixes #5 

Makes version range in .nuspec file inclusive so `EPiServer.CMS.TinyMce` 5.0.0 is supported.