### PR TITLE
Refactoring nuspec/pack script to allow for more finite controls of TinyMCE depdency versions

### DIFF
--- a/MSBuild/DependencyVersions.props
+++ b/MSBuild/DependencyVersions.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TinyVersion>3.2.0</TinyVersion>
+    <TinyMinVersion>3.2.0</TinyMinVersion>
+    <TinyMaxVersion>5.0.1</TinyMaxVersion>
   </PropertyGroup>
 </Project>

--- a/MSBuild/pack.ps1
+++ b/MSBuild/pack.ps1
@@ -8,11 +8,10 @@ $buildDir = "$solutionDir/msbuild"
 Write-Host "Creating TinymceDamPicker Package"
 
 [xml] $versionFile = Get-Content "$buildDir/DependencyVersions.props"
-$node = $versionFile.SelectSingleNode("Project/PropertyGroup/TinyVersion")
-$tinyVersion = $node.InnerText
-$parts = $tinyVersion.Split(".")
-$major = [int]::Parse($parts[0]) + 2
-$tinyNextMajorVersion = ($major.ToString() + ".0.0")
+$minNode = $versionFile.SelectSingleNode("Project/PropertyGroup/TinyMinVersion")
+$tinyVersion = $minNode.InnerText
+$maxNode = $versionFile.SelectSingleNode("Project/PropertyGroup/TinyMaxVersion")
+$tinyNextMajorVersion = $maxNode.InnerText
 
 [xml] $versionFile = Get-Content "$buildDir/version.props"
 $pVersion = $versionFile.SelectSingleNode("Project/PropertyGroup/VersionPrefix").InnerText + $versionSuffix

--- a/MSBuild/version.props
+++ b/MSBuild/version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.2.5</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ services.AddDamSelectButton();
 
  | Version | Details                                                                        |
  |:--------|:-------------------------------------------------------------------------------|
+ | 1.3.0   | Refactor to allow for easier TinyMCE dependency version updates                |
+ | 1.2.6   | Adding support for EPiServer.CMS.TinyMce 5.0                                   | 
  | 1.2.5   | Bug fix: Prevent multi-select. Thanks for the contribution AnnamalaiEswaran-A! | 
  | 1.2.4   | Bug fix: Ensure auto-save works when in forms view                             | 
  | 1.2.3   | Bug fix: Resolve issue where multiple images cannot be inserted                | 

--- a/TinymceDamPicker/TinymceDamPicker.csproj
+++ b/TinymceDamPicker/TinymceDamPicker.csproj
@@ -9,8 +9,8 @@
     <NuspecFile>TinymceDamPicker.nuspec</NuspecFile>
     <IsPackable>true</IsPackable>
     <PackageOutputPath>$(SolutionDir)artifacts\packages\</PackageOutputPath>
-    <NuspecProperties>Configuration=$(Configuration);version=$(PackageVersion);tinyVersion=$(TinyVersion);tinyNextMajorVersion=$(TinyNextMajorVersion)</NuspecProperties>
-      <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+    <NuspecProperties>Configuration=$(Configuration);version=$(PackageVersion);tinyVersion=$(TinyMinVersion);tinyNextMajorVersion=$(TinyMaxVersion)</NuspecProperties>
+    <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
   </PropertyGroup>
  
   <ItemGroup>
@@ -18,7 +18,7 @@
       <EmbeddedResource Include="ClientResources\**\*.*" />
   </ItemGroup>
 	<ItemGroup>
-        <PackageReference Include="EPiServer.CMS.TinyMce" Version="$(TinyVersion)" />
+        <PackageReference Include="EPiServer.CMS.TinyMce" Version="[$(TinyMinVersion),$(TinyMaxVersion)]" />
         <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Creates a min/max version parameter for finite controls instead of relying on a "set version +2" system.