### PR TITLE
Add support for custom anti-forgery token header name

### DIFF
--- a/TinymceDamPicker/ClientResources/tinymcedampicker/plugin.js
+++ b/TinymceDamPicker/ClientResources/tinymcedampicker/plugin.js
@@ -32,6 +32,11 @@ tinyMCE.PluginManager.add("tinymcedampicker", (editor, url) => {
         return token[0].value;
     }
 
+    var getRequestVerificationTokenHeaderName = function () {
+        const root = document.getElementById("epi-navigation-root");
+        return root?.dataset.epiAntiforgeryHeaderName?.toString() ?? "Requestverificationtoken";
+    }
+
     var openDialog = function () {
         dialogOpen = true;
         return editor.windowManager.open({
@@ -151,7 +156,7 @@ tinyMCE.PluginManager.add("tinymcedampicker", (editor, url) => {
                     headers: {
                         "Accept": "application/javascript, application/json",
                         "Content-type": "application/json",
-                        "Requestverificationtoken": getRequestVerificationToken(),
+                        [getRequestVerificationTokenHeaderName()]: getRequestVerificationToken(),
                         "X-Epicontentlanguage": "en",
                         "X-Epicurrentcontentcontext": "0",
                         "X-Requested-With": "XMLHttpRequest"


### PR DESCRIPTION
Fix error inserting image into rich text field when XSRF token header name has been customized.

Steps to reproduce:

- Add something like this to your startup
```
services.Configure<AntiforgeryOptions>(o =>
{
    o.HeaderName = "X-XSRF-TOKEN";
});
```
- Edit something with a rich text field
- Click the plugin's DAM button in tinymce
- Choose an image from the library picker
- Click the plugin's "Insert/update image" button
- Nothing happens
- Console shows the call to `/EPiServer.Cms.WelcomeIntegration.UI/Stores/episervercmsdamcontentcreation/` fails with an http 400

I have tested this fix locally with, and without the customized header name.