### PR TITLE
Support for custom anti-forgery token header name, and update episerver tinymce version

### DIFF
--- a/MSBuild/DependencyVersions.props
+++ b/MSBuild/DependencyVersions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <TinyMinVersion>3.2.0</TinyMinVersion>
-    <TinyMaxVersion>5.0.1</TinyMaxVersion>
+    <TinyMaxVersion>6</TinyMaxVersion>
   </PropertyGroup>
 </Project>

--- a/TinymceDamPicker/ClientResources/tinymcedampicker/plugin.js
+++ b/TinymceDamPicker/ClientResources/tinymcedampicker/plugin.js
@@ -32,6 +32,11 @@ tinyMCE.PluginManager.add("tinymcedampicker", (editor, url) => {
         return token[0].value;
     }
 
+    var getRequestVerificationTokenHeaderName = function () {
+        const root = document.getElementById("epi-navigation-root");
+        return root?.dataset.epiAntiforgeryHeaderName?.toString() ?? "Requestverificationtoken";
+    }
+
     var openDialog = function () {
         dialogOpen = true;
         return editor.windowManager.open({
@@ -151,7 +156,7 @@ tinyMCE.PluginManager.add("tinymcedampicker", (editor, url) => {
                     headers: {
                         "Accept": "application/javascript, application/json",
                         "Content-type": "application/json",
-                        "Requestverificationtoken": getRequestVerificationToken(),
+                        [getRequestVerificationTokenHeaderName()]: getRequestVerificationToken(),
                         "X-Epicontentlanguage": "en",
                         "X-Epicurrentcontentcontext": "0",
                         "X-Requested-With": "XMLHttpRequest"

--- a/TinymceDamPicker/TinymceDamPicker.csproj
+++ b/TinymceDamPicker/TinymceDamPicker.csproj
@@ -18,7 +18,7 @@
       <EmbeddedResource Include="ClientResources\**\*.*" />
   </ItemGroup>
 	<ItemGroup>
-        <PackageReference Include="EPiServer.CMS.TinyMce" Version="[$(TinyMinVersion),$(TinyMaxVersion)]" />
+        <PackageReference Include="EPiServer.CMS.TinyMce" Version="[$(TinyMinVersion),$(TinyMaxVersion))" />
         <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Includes the fix from https://github.com/davidknipe/TinymceDamPicker/pull/8 and allows any episerver tinymce 5.x version (5.0.3 is out as of this PR)